### PR TITLE
Feat/auth backend

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -68,7 +68,7 @@ def create_app(config_class=Config):
     app.register_blueprint(events_bp)
     app.register_blueprint(entrants_bp)
     app.register_blueprint(matches_bp)
-    app.register_blueprint(auth_bp)
+    app.register_blueprint(auth_bp, url_prefix="/api")
 
     return app
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -65,9 +65,9 @@ def create_app(config_class=Config):
     # ------------------------
     # Register Blueprints
     # ------------------------
-    app.register_blueprint(events_bp)
-    app.register_blueprint(entrants_bp)
-    app.register_blueprint(matches_bp)
+    app.register_blueprint(events_bp, url_prefix="/api/events")
+    app.register_blueprint(entrants_bp, url_prefix="/api/entrants")
+    app.register_blueprint(matches_bp, url_prefix="/api/matches")
     app.register_blueprint(auth_bp, url_prefix="/api")
 
     return app

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,4 +1,4 @@
-# backend/app/routes/auth.py
+# File: backend/app/routes/auth.py
 # Provides signup, login, logout, and protected routes
 # Uses JWT for token-based authentication
 # Logout revokes tokens by adding their JTI to a global blocklist
@@ -21,7 +21,9 @@ auth_bp = Blueprint("auth", __name__)
 @auth_bp.route("/signup", methods=["POST"])
 def signup():
     data = request.get_json() or {}
-    print("DEBUG signup payload:", data)
+    # redact password before logging
+    safe_data = {k: v for k, v in data.items() if k != "password"}
+    print("DEBUG signup payload:", safe_data)
 
     try:
         username = data.get("username")
@@ -51,7 +53,9 @@ def signup():
 @auth_bp.route("/login", methods=["POST"])
 def login():
     data = request.get_json() or {}
-    print("DEBUG login payload:", data)
+    # redact password before logging
+    safe_data = {k: v for k, v in data.items() if k != "password"}
+    print("DEBUG login payload:", safe_data)
 
     try:
         email = data.get("email")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ click==8.2.1
 flake8==7.1.1
 Flask==3.1.2
 Flask-Cors==6.0.1
+Flask-JWT-Extended==4.7.1
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 iniconfig==2.1.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -10,7 +10,7 @@ import time
 
 def test_signup_creates_user(client):
     resp = client.post(
-        "/signup",
+        "/api/signup",
         json={
             "username": "alice",
             "email": "alice@example.com",
@@ -25,11 +25,11 @@ def test_signup_creates_user(client):
 
 def test_login_returns_token(client):
     client.post(
-        "/signup",
+        "/api/signup",
         json={"username": "bob", "email": "bob@example.com", "password": "secret"},
     )
     resp = client.post(
-        "/login", json={"email": "bob@example.com", "password": "secret"}
+        "/api/login", json={"email": "bob@example.com", "password": "secret"}
     )
     assert resp.status_code == 200
     token = resp.get_json().get("access_token")
@@ -37,47 +37,45 @@ def test_login_returns_token(client):
 
 
 def test_protected_route_requires_auth(client):
-    resp = client.get("/protected")
+    resp = client.get("/api/protected")
     assert resp.status_code == 401
-    # now expect "Missing Authorization Header"
     assert resp.get_json()["error"] == "Missing Authorization Header"
 
 
 def test_protected_route_with_auth(client):
     client.post(
-        "/signup",
+        "/api/signup",
         json={"username": "cathy", "email": "cathy@example.com", "password": "pass"},
     )
     login_resp = client.post(
-        "/login", json={"email": "cathy@example.com", "password": "pass"}
+        "/api/login", json={"email": "cathy@example.com", "password": "pass"}
     )
     token = login_resp.get_json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
-    resp = client.get("/protected", headers=headers)
+    resp = client.get("/api/protected", headers=headers)
     assert resp.status_code == 200
     assert "message" in resp.get_json()
 
 
 def test_logout_returns_ok(client):
     client.post(
-        "/signup",
+        "/api/signup",
         json={"username": "dave", "email": "dave@example.com", "password": "mypw"},
     )
     login_resp = client.post(
-        "/login", json={"email": "dave@example.com", "password": "mypw"}
+        "/api/login", json={"email": "dave@example.com", "password": "mypw"}
     )
     token = login_resp.get_json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
-    logout_resp = client.delete("/logout", headers=headers)
+    logout_resp = client.delete("/api/logout", headers=headers)
     assert logout_resp.status_code == 200
-    # normalize to "Logged out"
     assert logout_resp.get_json()["message"] == "Logged out"
 
 
 def test_login_with_wrong_password(client, session):
-    from backend.app.models import User
+    from backend.app.models.models import User
 
     user = User(username="edgeuser", email="edge@example.com")
     user.set_password("correctpass")
@@ -85,14 +83,14 @@ def test_login_with_wrong_password(client, session):
     session.commit()
 
     resp = client.post(
-        "/login", json={"email": "edge@example.com", "password": "wrongpass"}
+        "/api/login", json={"email": "edge@example.com", "password": "wrongpass"}
     )
     assert resp.status_code == 401
     assert resp.get_json()["error"] == "Invalid credentials"
 
 
 def test_signup_with_duplicate_email(client, session):
-    from backend.app.models import User
+    from backend.app.models.models import User
 
     user = User(username="dup", email="dup@example.com")
     user.set_password("pass")
@@ -100,7 +98,7 @@ def test_signup_with_duplicate_email(client, session):
     session.commit()
 
     resp = client.post(
-        "/signup",
+        "/api/signup",
         json={"username": "dup2", "email": "dup@example.com", "password": "pass"},
     )
     assert resp.status_code == 400
@@ -109,25 +107,23 @@ def test_signup_with_duplicate_email(client, session):
 
 def test_protected_route_with_invalid_token(client):
     headers = {"Authorization": "Bearer not.a.real.token"}
-    resp = client.get("/protected", headers=headers)
+    resp = client.get("/api/protected", headers=headers)
 
     assert resp.status_code == 401
-    # now guaranteed normalized
     assert resp.get_json()["error"] == "Invalid or expired token"
 
 
 def test_delete_event_requires_auth(client, create_event):
     event = create_event()
-    resp = client.delete(f"/events/{event.id}")
+    resp = client.delete(f"/api/events/{event.id}")
     assert resp.status_code == 401
-    # same change here: missing header should match exactly
     assert resp.get_json()["error"] == "Missing Authorization Header"
 
 
 def test_create_entrant_with_auth(client, create_event, auth_header):
     event = create_event()
     data = {"name": "HeroEdge", "alias": "Edgecase", "event_id": event.id}
-    resp = client.post("/entrants", json=data, headers=auth_header)
+    resp = client.post("/api/entrants", json=data, headers=auth_header)
     assert resp.status_code == 201
     body = resp.get_json()
     assert body["name"] == "HeroEdge"
@@ -135,7 +131,7 @@ def test_create_entrant_with_auth(client, create_event, auth_header):
 
 
 def test_signup_missing_fields(client):
-    resp = client.post("/signup", json={"email": "no_user@example.com"})
+    resp = client.post("/api/signup", json={"email": "no_user@example.com"})
     assert resp.status_code == 400
     error = resp.get_json()["error"].lower()
     assert "missing" in error or "required" in error
@@ -145,10 +141,9 @@ def test_signup_missing_fields(client):
 # Expiry + revocation tests
 # -------------------------
 
-
 def test_expired_token_denied(client):
     client.post(
-        "/signup",
+        "/api/signup",
         json={
             "username": "expireuser",
             "email": "expire@example.com",
@@ -156,35 +151,48 @@ def test_expired_token_denied(client):
         },
     )
     login_resp = client.post(
-        "/login", json={"email": "expire@example.com", "password": "pw"}
+        "/api/login", json={"email": "expire@example.com", "password": "pw"}
     )
     token = login_resp.get_json()["access_token"]
 
-    # wait for expiry (config sets very short expiry in test env)
-    time.sleep(2)
+    time.sleep(2)  # short expiry in test config
 
     headers = {"Authorization": f"Bearer {token}"}
-    resp = client.get("/protected", headers=headers)
+    resp = client.get("/api/protected", headers=headers)
     assert resp.status_code == 401
     assert resp.get_json()["error"] == "Invalid or expired token"
 
 
 def test_revoked_token_denied(client):
     client.post(
-        "/signup",
+        "/api/signup",
         json={"username": "revoker", "email": "revoker@example.com", "password": "pw"},
     )
     login_resp = client.post(
-        "/login", json={"email": "revoker@example.com", "password": "pw"}
+        "/api/login", json={"email": "revoker@example.com", "password": "pw"}
     )
     token = login_resp.get_json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
-    # logout → token should be revoked
-    client.delete("/logout", headers=headers)
+    client.delete("/api/logout", headers=headers)  # logout → revoke token
 
-    # attempt to reuse token
-    resp = client.get("/protected", headers=headers)
+    resp = client.get("/api/protected", headers=headers)
     assert resp.status_code == 401
-    # now normalized to one message
     assert resp.get_json()["error"] == "Invalid or expired token"
+
+
+def test_password_is_hashed_in_db(client, session):
+    resp = client.post(
+        "/api/signup",
+        json={"username": "hashme", "email": "hash@example.com", "password": "rawpass"},
+    )
+    assert resp.status_code == 201
+
+    from backend.app.models.models import User
+    user = session.query(User).filter_by(email="hash@example.com").first()
+
+    # The hash should be different from the raw password
+    assert user.password_hash != "rawpass"
+
+    # And check_password should succeed
+    assert user.check_password("rawpass")

--- a/backend/tests/test_routes_entrants.py
+++ b/backend/tests/test_routes_entrants.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 def test_create_entrant(client, create_event, auth_header):
     event = create_event()
     response = client.post(
-        "/entrants",
+        "/api/entrants",
         json={"name": "Spiderman", "alias": "Webslinger", "event_id": event.id},
         headers=auth_header,
     )
@@ -29,7 +29,7 @@ def test_get_entrants(client, create_event, session):
     session.add(entrant)
     session.commit()
 
-    response = client.get("/entrants")
+    response = client.get("/api/entrants")
     assert response.status_code == 200
     data = response.get_json()
     assert any(ent["name"] == "Batman" for ent in data)
@@ -42,7 +42,7 @@ def test_update_entrant(client, create_event, session, auth_header):
     session.commit()
 
     response = client.put(
-        f"/entrants/{entrant.id}", json={"alias": "Updated Alias"}, headers=auth_header
+        f"/api/entrants/{entrant.id}", json={"alias": "Updated Alias"}, headers=auth_header
     )
     assert response.status_code == 200
     assert response.get_json()["alias"] == "Updated Alias"
@@ -57,7 +57,7 @@ def test_delete_entrant_hard_delete_when_no_matches(client, create_event, sessio
     session.add(entrant)
     session.commit()
 
-    response = client.delete(f"/entrants/{entrant.id}", headers=auth_header)
+    response = client.delete(f"/api/entrants/{entrant.id}", headers=auth_header)
     assert response.status_code == 204
     assert db.session.get(Entrant, entrant.id) is None
 
@@ -75,7 +75,7 @@ def test_delete_entrant_soft_delete_when_in_match(client, seed_event_with_entran
     session.add(match)
     session.commit()
 
-    response = client.delete(f"/entrants/{e1.id}", headers=auth_header)
+    response = client.delete(f"/api/entrants/{e1.id}", headers=auth_header)
     assert response.status_code == 200
     data = response.get_json()
     assert data["dropped"] is True
@@ -89,5 +89,5 @@ def test_delete_entrant_soft_delete_when_in_match(client, seed_event_with_entran
 
 def test_create_entrant_requires_auth(client, create_event):
     event = create_event()
-    resp = client.post("/entrants", json={"name": "Fail", "event_id": event.id})
+    resp = client.post("/api/entrants", json={"name": "Fail", "event_id": event.id})
     assert resp.status_code == 401

--- a/backend/tests/test_routes_matches.py
+++ b/backend/tests/test_routes_matches.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 def test_create_match(client, seed_event_with_entrants, auth_header):
     event, e1, e2 = seed_event_with_entrants()
     response = client.post(
-        "/matches",
+        "/api/matches",
         json={
             "event_id": event.id,
             "round": 1,
@@ -32,14 +32,14 @@ def test_create_match(client, seed_event_with_entrants, auth_header):
 def test_create_match_rejects_invalid_winner(client, seed_event_with_entrants, auth_header):
     event, e1, e2 = seed_event_with_entrants()
     resp = client.post(
-        "/matches",
+        "/api/matches",
         json={
             "event_id": event.id,
             "round": 1,
             "entrant1_id": e1.id,
             "entrant2_id": e2.id,
             "scores": "2-1",
-            "winner_id": 999,  # not one of the entrants
+            "winner_id": 999,
         },
         headers=auth_header,
     )
@@ -53,7 +53,7 @@ def test_get_matches(client, seed_event_with_entrants, session):
     session.add(match)
     session.commit()
 
-    response = client.get("/matches")
+    response = client.get("/api/matches")
     assert response.status_code == 200
     matches = response.get_json()
     assert any(m["scores"] == "1-0" for m in matches)
@@ -65,7 +65,7 @@ def test_update_match(client, seed_event_with_entrants, session, auth_header):
     session.add(match)
     session.commit()
 
-    response = client.put(f"/matches/{match.id}", json={"scores": "2-0"}, headers=auth_header)
+    response = client.put(f"/api/matches/{match.id}", json={"scores": "2-0"}, headers=auth_header)
     assert response.status_code == 200
     assert response.get_json()["scores"] == "2-0"
 
@@ -79,7 +79,7 @@ def test_delete_match(client, seed_event_with_entrants, session, auth_header):
     session.add(match)
     session.commit()
 
-    response = client.delete(f"/matches/{match.id}", headers=auth_header)
+    response = client.delete(f"/api/matches/{match.id}", headers=auth_header)
     assert response.status_code == 204
     assert db.session.get(Match, match.id) is None
 
@@ -87,7 +87,7 @@ def test_delete_match(client, seed_event_with_entrants, session, auth_header):
 def test_create_match_requires_auth(client, seed_event_with_entrants):
     event, e1, e2 = seed_event_with_entrants()
     resp = client.post(
-        "/matches",
+        "/api/matches",
         json={
             "event_id": event.id,
             "round": 1,


### PR DESCRIPTION
## Summary
Refactored backend API routes to include `/api` prefixes and updated corresponding test suites. Verified password hashing behavior and ensured all authentication and CRUD route tests pass.

## Changes
- **App Initialization**
  - Registered all blueprints with `/api` prefixes:
    - `/api/events`
    - `/api/entrants`
    - `/api/matches`
    - `/api` (auth routes)
- **Auth**
  - Verified signup/login/logout/protected routes under `/api` namespace
  - Ensured password hashing uses Werkzeug and no raw passwords are returned
- **Tests**
  - Updated `test_auth.py` to point at `/api/signup`, `/api/login`, etc.
  - Updated `test_routes_events.py` to use `/api/events`
  - Updated `test_routes_entrants.py` to use `/api/entrants`
  - Updated `test_routes_matches.py` to use `/api/matches`
  - Added explicit test for password hashing (`test_password_is_hashed_in_db`)

## Notes
- All backend tests passing (auth, events, entrants, matches)
- JWT blocklist + custom error handlers confirmed working
- Passwords are hashed in DB and never returned in API responses