### PR TITLE
feat(auth): branch home route by admin status and update AuthContext persistence

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -53,7 +53,6 @@ def signup():
 @auth_bp.route("/login", methods=["POST"])
 def login():
     data = request.get_json() or {}
-    # redact password before logging
     safe_data = {k: v for k, v in data.items() if k != "password"}
     print("DEBUG login payload:", safe_data)
 
@@ -67,7 +66,7 @@ def login():
 
         token = create_access_token(identity=str(user.id))
         print(f"✅ Login success for {email}")
-        return jsonify(access_token=token), 200
+        return jsonify(access_token=token, user=user.to_dict()), 200
     except Exception as e:
         traceback.print_exc()
         print(f"❌ Error during login: {e}")


### PR DESCRIPTION
## Summary
Implements branching logic for authenticated users based on `is_admin` flag and ensures consistent persistence of user/token in context.

## Changes
- **App.jsx**
  - Root route redirects:
    - Admins → `/events`
    - Non-admin users → `/dashboard`
    - Logged-out users → `/login`
  - Protects `/events` and `/events/:id` with `ProtectedRoute`
- **AuthContext.js**
  - Persists both `token` and `user` to `localStorage`
  - Normalizes `userData` to always include `is_admin` (default `false`)
  - Ensures logout clears local state even if API call fails
  - Aligns signup/login responses for consistent state updates

## Notes
- Current behavior: any authenticated user can still manually access `/events`; future work may add an `AdminRoute` for stricter access
- Future user story planned: allow logged-out “fans” to browse dashboards with limited data access
