### PR TITLE
Feat/choose hero

### DIFF
--- a/frontend/src/components/Heroes.jsx
+++ b/frontend/src/components/Heroes.jsx
@@ -239,9 +239,13 @@ export default function Heroes() {
               variant="contained"
               color="primary"
               onClick={() => {
-                console.log("Choose Hero:", selectedHero?.id);
+                if (selectedHero) {
+                  // persist to localStorage
+                  localStorage.setItem("chosenHero", JSON.stringify(selectedHero));
+                  console.log("✅ Hero saved:", selectedHero.id, selectedHero.name);
+                }
                 setSelectedHero(null);
-              }}
+              }}            
             >
               Choose Hero
             </Button>

--- a/frontend/src/components/Heroes.jsx
+++ b/frontend/src/components/Heroes.jsx
@@ -213,7 +213,6 @@ export default function Heroes() {
                   boxShadow: "0 2px 6px rgba(0,0,0,0.2)",
                 }}
                 onError={(e) => {
-                  // Fallback to the external URL if the proxy ever 502s
                   if (selectedHero?.image && e.currentTarget.src !== selectedHero.image) {
                     e.currentTarget.src = selectedHero.image;
                   }
@@ -225,27 +224,44 @@ export default function Heroes() {
               No image available
             </Typography>
           )}
+
+          {/* Alignment emphasized higher up */}
+          <Typography align="center" sx={{ fontWeight: "bold", mb: 1 }}>
+            {selectedHero?.alignment?.toUpperCase() || "UNKNOWN"}
+          </Typography>
+
           <Typography>
             <strong>Full Name:</strong> {selectedHero?.full_name || "-"}
           </Typography>
           <Typography>
             <strong>Alias:</strong> {selectedHero?.alias || "-"}
           </Typography>
-          <Typography>
-            <strong>Alignment:</strong> {selectedHero?.alignment || "-"}
-          </Typography>
+
+          {/* Powerstats list */}
+          {selectedHero?.powerstats && (
+            <Box sx={{ mt: 2 }}>
+              {Object.entries(selectedHero.powerstats).map(([stat, val]) => (
+                <Typography key={stat}>
+                  {stat.charAt(0).toUpperCase() + stat.slice(1)}: {val}
+                </Typography>
+              ))}
+            </Box>
+          )}
+
           <Box sx={{ mt: 3, textAlign: "center" }}>
             <Button
               variant="contained"
               color="primary"
               onClick={() => {
-                if (selectedHero) {
-                  // persist to localStorage
-                  localStorage.setItem("chosenHero", JSON.stringify(selectedHero));
-                  console.log("✅ Hero saved:", selectedHero.id, selectedHero.name);
+                const existing = localStorage.getItem("chosenHero");
+                if (existing) {
+                  if (!window.confirm("You already selected a hero. Replace them?")) {
+                    return;
+                  }
                 }
+                localStorage.setItem("chosenHero", JSON.stringify(selectedHero));
                 setSelectedHero(null);
-              }}            
+              }}
             >
               Choose Hero
             </Button>

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -1,19 +1,27 @@
 // File: frontend/src/components/UserDashboard.jsx
 // Purpose: Landing page for non-admin participants.
 // Notes:
-// - Displays welcome + selected heroes summary.
-// - Provides entry point to Hero Selection (Heroes.jsx).
-// - Future: add brackets/analytics view.
+// - Displays welcome + selected hero card styled like battle page.
+// - Shows powerstats + alignment prominently.
+// - Includes "Choose Another Hero" button.
+// - Placeholder parallel card for future analytics.
 
 import { useAuth } from "../context/AuthContext";
-import { Container, Typography, Button, Box, Card, CardContent } from "@mui/material";
+import {
+  Container,
+  Typography,
+  Button,
+  Box,
+  Card,
+  CardContent,
+  Grid,
+} from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 
 export default function UserDashboard() {
   const { user } = useAuth();
   const navigate = useNavigate();
-
   const [chosenHero, setChosenHero] = useState(null);
 
   useEffect(() => {
@@ -29,53 +37,96 @@ export default function UserDashboard() {
 
   return (
     <Container sx={{ mt: 4 }} data-testid="user-dashboard">
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="h4" gutterBottom align="center" sx={{ mb: 4 }}>
         Welcome, {user?.username || "Participant"}
       </Typography>
 
-      <Box sx={{ my: 3 }}>
-        {chosenHero ? (
-          <Card sx={{ maxWidth: 400, p: 2 }}>
-            <CardContent>
-              <Typography variant="h6">{chosenHero.name}</Typography>
-              <Typography variant="subtitle2" gutterBottom>
-                {chosenHero.full_name || "-"}
-              </Typography>
-              {chosenHero.proxy_image && (
+      <Grid container spacing={4} justifyContent="center">
+        {/* Hero card */}
+        <Grid item xs={12} md={6}>
+          {chosenHero ? (
+            <Card sx={{ p: 2 }}>
+              <CardContent>
+                <Typography
+                  variant="h6"
+                  align="center"
+                  sx={{ fontWeight: "bold", mb: 2 }}
+                >
+                  {chosenHero.alignment?.toUpperCase() || "UNKNOWN"}
+                </Typography>
                 <Box textAlign="center" mb={2}>
-                  <img
-                    src={chosenHero.proxy_image}
-                    alt={chosenHero.name}
-                    style={{ maxWidth: "100%", borderRadius: "8px" }}
-                  />
+                  {chosenHero.proxy_image && (
+                    <img
+                      src={chosenHero.proxy_image}
+                      alt={chosenHero.name}
+                      style={{
+                        maxWidth: "100%",
+                        borderRadius: "8px",
+                        boxShadow: "0 2px 6px rgba(0,0,0,0.2)",
+                      }}
+                    />
+                  )}
                 </Box>
-              )}
-              <Typography>
-                <strong>Alias:</strong> {chosenHero.alias || "-"}
+                <Typography variant="h5" align="center" gutterBottom>
+                  {chosenHero.name}
+                </Typography>
+                <Typography align="center" gutterBottom>
+                  {chosenHero.full_name || "-"}
+                </Typography>
+                <Typography>
+                  <strong>Alias:</strong> {chosenHero.alias || "-"}
+                </Typography>
+                <Box sx={{ mt: 2 }}>
+                  {chosenHero.powerstats &&
+                    Object.entries(chosenHero.powerstats).map(([stat, val]) => (
+                      <Typography key={stat}>
+                        {stat.charAt(0).toUpperCase() + stat.slice(1)}: {val}
+                      </Typography>
+                    ))}
+                </Box>
+                <Box sx={{ mt: 3, textAlign: "center" }}>
+                  <Button
+                    variant="outlined"
+                    color="secondary"
+                    onClick={() => navigate("/heroes")}
+                  >
+                    Choose Another Hero
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card sx={{ p: 2 }}>
+              <CardContent sx={{ textAlign: "center" }}>
+                <Typography variant="body1" gutterBottom>
+                  You haven’t selected your hero yet.
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => navigate("/heroes")}
+                >
+                  Choose Hero
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </Grid>
+
+        {/* Placeholder analytics card */}
+        <Grid item xs={12} md={6}>
+          <Card sx={{ p: 2, minHeight: "100%" }}>
+            <CardContent sx={{ textAlign: "center" }}>
+              <Typography variant="h6" gutterBottom>
+                Future Analytics
               </Typography>
-              <Typography>
-                <strong>Alignment:</strong> {chosenHero.alignment || "-"}
+              <Typography variant="body2" color="text.secondary">
+                Stats and performance tracking will appear here.
               </Typography>
             </CardContent>
           </Card>
-        ) : (
-          <>
-            <Typography variant="body1">
-              You haven't selected your hero yet.
-            </Typography>
-            <Button
-              variant="contained"
-              color="primary"
-              sx={{ mt: 2 }}
-              onClick={() => navigate("/heroes")}
-            >
-              Choose Hero
-            </Button>
-          </>
-        )}
-      </Box>
-
-      {/* TODO: add future sections like bracket view, analytics, etc. */}
+        </Grid>
+      </Grid>
     </Container>
   );
 }

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -6,12 +6,26 @@
 // - Future: add brackets/analytics view.
 
 import { useAuth } from "../context/AuthContext";
-import { Container, Typography, Button, Box } from "@mui/material";
+import { Container, Typography, Button, Box, Card, CardContent } from "@mui/material";
 import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
 
 export default function UserDashboard() {
   const { user } = useAuth();
   const navigate = useNavigate();
+
+  const [chosenHero, setChosenHero] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("chosenHero");
+    if (stored) {
+      try {
+        setChosenHero(JSON.parse(stored));
+      } catch {
+        setChosenHero(null);
+      }
+    }
+  }, []);
 
   return (
     <Container sx={{ mt: 4 }} data-testid="user-dashboard">
@@ -20,18 +34,45 @@ export default function UserDashboard() {
       </Typography>
 
       <Box sx={{ my: 3 }}>
-        {/* TODO: show selected heroes if any */}
-        <Typography variant="body1">
-          You haven’t selected your heroes yet.
-        </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          sx={{ mt: 2 }}
-          onClick={() => navigate("/heroes")}
-        >
-          Choose Heroes
-        </Button>
+        {chosenHero ? (
+          <Card sx={{ maxWidth: 400, p: 2 }}>
+            <CardContent>
+              <Typography variant="h6">{chosenHero.name}</Typography>
+              <Typography variant="subtitle2" gutterBottom>
+                {chosenHero.full_name || "-"}
+              </Typography>
+              {chosenHero.proxy_image && (
+                <Box textAlign="center" mb={2}>
+                  <img
+                    src={chosenHero.proxy_image}
+                    alt={chosenHero.name}
+                    style={{ maxWidth: "100%", borderRadius: "8px" }}
+                  />
+                </Box>
+              )}
+              <Typography>
+                <strong>Alias:</strong> {chosenHero.alias || "-"}
+              </Typography>
+              <Typography>
+                <strong>Alignment:</strong> {chosenHero.alignment || "-"}
+              </Typography>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Typography variant="body1">
+              You haven't selected your hero yet.
+            </Typography>
+            <Button
+              variant="contained"
+              color="primary"
+              sx={{ mt: 2 }}
+              onClick={() => navigate("/heroes")}
+            >
+              Choose Hero
+            </Button>
+          </>
+        )}
       </Box>
 
       {/* TODO: add future sections like bracket view, analytics, etc. */}


### PR DESCRIPTION
## Summary
Wired up hero selection from modal into the User Dashboard. Added card-based layout similar to battle screen with alignment, image, and powerstats. Introduced confirmation when replacing an already selected hero and prepared a placeholder for analytics display.

## Changes
- **Heroes modal**
  - Display alignment higher in the card layout
  - Show full powerstats (intelligence, strength, speed, durability, power, combat)
  - Added confirmation dialog if replacing an existing selected hero
- **User Dashboard**
  - Render selected hero card with image, alignment, and stats
  - Added "Choose Another Hero" button to return to Heroes page
  - Added parallel placeholder card for future analytics/metrics
- **State wiring**
  - Connected hero selection from modal → persisted on dashboard
  - Preserved ability to reselect hero with explicit confirmation

## Notes
- Modal + dashboard card layout mirrors battle view styling for consistency
- Placeholder card is scaffold only, no backend data yet; future work to connect analytics card to tracked stats once available
